### PR TITLE
Fix/olazo coding standards

### DIFF
--- a/modules/olazo.py
+++ b/modules/olazo.py
@@ -3,7 +3,7 @@ import os
 CHOICES = (0, 1, 2, 3, 4)
 
 def display_menu():
-    """ Display the main menu """
+    """Display the main menu"""
     print(
         "=== This is John Albert Olazo's ===\n"
         "[1] Basic Info\n"
@@ -14,7 +14,7 @@ def display_menu():
     )
 
 def get_user_choice():
-    """ Get the user's choice from the menu """
+    """Get the user's choice from the menu"""
     user_input = input("Enter your choice: ")
 
     if user_input.isdigit():
@@ -29,7 +29,7 @@ def get_user_choice():
     return None
 
 def display_basic_info():
-    """ Display Albert's basic information """
+    """Display Albert's basic information"""
     print(
         "Basic Information:\n"
         "\tName: John Albert Olazo\n"
@@ -38,7 +38,7 @@ def display_basic_info():
     )
 
 def display_goals():
-    """ Display Albert's goals """
+    """Display Albert's goals"""
     print(
         "Goals:\n"
         "\t1. Graduate with a bachelor's degree in Information Technology\n"
@@ -47,7 +47,7 @@ def display_goals():
     )
 
 def handle_user_choice(choice):
-    """ Handle the user's choice from the menu """
+    """Handle the user's choice from the menu"""
     match choice:
         case 1:
             display_basic_info()
@@ -62,7 +62,7 @@ def handle_user_choice(choice):
                 "Helping your family is a meaningful act of love.\n")
 
 def olazo_main():
-    """ Main function to run the program """
+    """Main function to run the program"""
     while True:
         os.system('cls' if os.name == 'nt' else 'clear')
         display_menu()


### PR DESCRIPTION
I have updated the ```olazo``` module to follow proper coding conventions:

- Simplified the if-else condition by using a guard clause in ```get_user_choice()```. See changes in commit [fef20b8](https://github.com/PUP-BSIT/exercise-13-mekus/pull/9/commits/fef20b840c184e9e94c8e79e7689412dc12ce310)
- Removed trailing whitespace from docstrings. See changes in commit [15b6def](https://github.com/PUP-BSIT/exercise-13-mekus/pull/9/commits/15b6def570ee96531b42abab3192f730e42bd765)

Kindly review the changes and let me know if any further adjustments are needed. Thank you!
