### PR TITLE
add import to __init__.py for package-level access

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+from .olazo import olazo_main


### PR DESCRIPTION
I have added the ```olazo_main``` import from the ```olazo``` module to ```__init__.py``` for easier access at the package level.

Please review the changes and let me know if any further adjustments are needed. Thank you!