### PR TITLE
remove direct call to olazo_main from olazo module

### DIFF
--- a/modules/olazo.py
+++ b/modules/olazo.py
@@ -81,5 +81,3 @@ def olazo_main():
         handle_user_choice(choice)
 
         input("Press Enter to continue...")
-
-olazo_main()


### PR DESCRIPTION
This PR removes the direct call to olazo_main() from the olazo module.

Details:
- Prevents the olazo module from executing automatically when imported.

Please review the changes and let me know if any further adjustments are needed. Thank you!