### PR TITLE
remove direct call to jundam_main from jundam module

### DIFF
--- a/modules/jundam.py
+++ b/modules/jundam.py
@@ -80,5 +80,3 @@ def jundam_main():
         handle_user_choice(choice)
 
         input("Press Enter to continue...\n")
-
-jundam_main()


### PR DESCRIPTION
This PR removes the direct call to jundam_main() from the jundam module. 

Details:
- Prevents the jundam module from executing automatically when imported. 

Please review the changes and let me know if any further adjustments are needed. Thank you!