### PR TITLE
remove direct call to dazo_main from dazo module

### DIFF
--- a/modules/dazo.py
+++ b/modules/dazo.py
@@ -88,5 +88,3 @@ def dazo_main():
         handle_user_choice(choice)
 
         input("\nPress Enter to return to menu...")
-
-dazo_main()


### PR DESCRIPTION
This PR removes the direct call to dazo_main() from the dazo module.

Details:

Prevents the dazo module from executing automatically when imported.
Please review the changes and let me know if any further adjustments are needed. Thank you!