### PR TITLE
remove direct call to serohijos_main from serohijos module

### DIFF
--- a/modules/serohijos.py
+++ b/modules/serohijos.py
@@ -90,5 +90,3 @@ def serohijos_main():
         handle_user_choice(choice)
 
         input("\nPress Enter to return to menu...")
-
-serohijos_main()


### PR DESCRIPTION
This PR removes the direct call to serohijos_main() from the serohijos module.

Details:

- Prevents the serohijos module from executing automatically when imported.

Please review the changes and let me know if any further adjustments are needed. Thank you!