### PR TITLE
remove direct call to agulto_main from agulto module

### DIFF
--- a/modules/agulto.py
+++ b/modules/agulto.py
@@ -78,5 +78,3 @@ def agulto_main():
         handle_user_choice(choice)
 
         input("Press Enter to continue...")
-
-agulto_main()


### PR DESCRIPTION
This PR removes the direct call to agulto_main() from the agulto module.

Details:

- Prevents the agulto module from executing automatically when imported.

Please review the changes and let me know if any further adjustments are needed. Thank you!